### PR TITLE
Fix device profile creation without EUD and clean up value type display

### DIFF
--- a/src/pages/DeviceProfiles.tsx
+++ b/src/pages/DeviceProfiles.tsx
@@ -103,7 +103,7 @@ export default function DeviceProfiles() {
                             }}
                         />;
 
-                        tableData.body.push([row.preference_key, row.preference_value, row.value_class, row.callsign, enrollment, connection, active, formatISO(parseISO(row.publish_time)), delete_button]);
+                        tableData.body.push([row.preference_key, row.preference_value, row.value_class.replace('class java.lang.', ''), row.callsign, enrollment, connection, active, formatISO(parseISO(row.publish_time)), delete_button]);
                     }
                 });
 

--- a/src/pages/DeviceProfiles.tsx
+++ b/src/pages/DeviceProfiles.tsx
@@ -144,7 +144,9 @@ export default function DeviceProfiles() {
         body.append('enrollment', String(profile.enrollment));
         body.append('connection', String(profile.connection));
         body.append('active', String(profile.active));
-        body.append('eud_uid', String(profile.eud_uid));
+        if (profile.eud_uid) {
+            body.append('eud_uid', profile.eud_uid);
+        }
         axios.post(apiRoutes.deviceProfiles, body)
             .then(r => {
                 if (r.status === 200) {


### PR DESCRIPTION
## Summary

- `String(null)` sends the literal string `"null"` as `eud_uid` when no callsign is selected, which violates the foreign key constraint on the server and silently prevents the profile from being created. Now only includes `eud_uid` in the form data when a callsign/EUD is actually selected.
- Strip the `class java.lang.` prefix from `value_class` when displaying in the table, so users see "String" instead of "class java.lang.String". The full Java class name is still stored and sent to devices as ATAK expects.

## Test plan

- [ ] Add a device profile without selecting a callsign — verify it is created and appears in the table
- [ ] Add a device profile with a callsign selected — verify it still works as before
- [ ] Verify the Value Type column shows "String", "Boolean", "Integer", "Float" instead of the full Java class names

Fixes brian7704/OpenTAKServer#253 (UI half — companion backend PR at brian7704/OpenTAKServer#283)

🤖 Generated with [Claude Code](https://claude.com/claude-code)