### PR TITLE
Convert Users and Groups pages to DataTable with sorting and records-per-page

### DIFF
--- a/src/pages/Groups.tsx
+++ b/src/pages/Groups.tsx
@@ -1,7 +1,7 @@
 import {
     Button,
-    Center, ComboboxItem, CopyButton, Grid, Modal, MultiSelect, NumberInput,
-    Pagination, Paper, PasswordInput, Select, Switch,
+    Center, ComboboxItem, Grid, Modal, MultiSelect, Paper,
+    Switch,
     Table,
     TableData, TextInput, Title, Tooltip,
     useComputedColorScheme,
@@ -10,13 +10,28 @@ import { notifications } from '@mantine/notifications';
 import React, { useEffect, useState } from 'react';
 import axios from "axios";
 import {apiRoutes} from "@/apiRoutes.tsx";
-import {IconCircleMinus, IconPlus, IconUserCog, IconUserMinus, IconX} from "@tabler/icons-react";
+import {IconCircleMinus, IconUserCog, IconUserMinus, IconX} from "@tabler/icons-react";
 import {t} from "i18next";
+import { DataTable, type DataTableSortStatus } from 'mantine-datatable';
+
+export interface Group {
+    name: string;
+    created: string;
+    type: string;
+    bitpos: number;
+    description: string;
+}
 
 export default function Groups() {
     const computedColorScheme = useComputedColorScheme('light', { getInitialValueInEffect: true });
     const [activePage, setPage] = useState(1);
-    const [totalPages, setTotalPages] = useState(1);
+    const [totalRecords, setTotalRecords] = useState(0);
+    const [loading, setLoading] = useState(false);
+    const [pageSize, setPageSize] = useState(10);
+    const [sortStatus, setSortStatus] = useState<DataTableSortStatus<Group>>({
+        columnAccessor: 'name',
+        direction: 'asc',
+    });
     const [groupToDelete, setGroupToDelete] = useState('');
     const [deleteGroupOpen, setDeleteGroupOpen] = useState(false);
     const [showAddGroup, setShowAddGroup] = useState(false);
@@ -31,11 +46,7 @@ export default function Groups() {
         head: [t('Username'), t('Direction'), t('Active')],
         body: [],
     });
-    const [groups, setGroups] = useState<TableData>({
-        caption: '',
-        head: [t('Name'), t('Created'), t('Type'), t('Bit Position'), t('Description')],
-        body: [],
-    });
+    const [groups, setGroups] = useState<Group[]>([]);
     const [newGroupProperties, setNewGroupProperties] = useState(
         {   name: '',
             created: '',
@@ -46,57 +57,42 @@ export default function Groups() {
     );
 
     function get_groups() {
-        axios.get(apiRoutes.groups, { params: {page: activePage,} })
+        if (loading) {
+            return;
+        }
+        setLoading(true);
+        axios.get(apiRoutes.groups, {
+            params: {
+                page: activePage,
+                per_page: pageSize,
+                sort_by: sortStatus.columnAccessor,
+                sort_direction: sortStatus.direction,
+            }
+        })
             .then((r) => {
+                setLoading(false);
                 if (r.status === 200) {
-                    const tableData: TableData = {
-                        caption: '',
-                        head: [t('Name'), t('Created'), t('Type'), t('Bit Position'), t('Description')],
-                        body: [],
-                    }
-
-                    r.data.results.map((row: any) => {
-                        if (tableData.body !== undefined) {
-                            const delete_button = <Button
-                                color="red"
-                                onClick={() => {
-                                    setGroupToDelete(row.name);
-                                    setDeleteGroupOpen(true);
-                                }}
-                                key={`${row.name}_delete`}
-                                disabled={row.name === "__ANON__"}
-                                rightSection={<IconCircleMinus size={14} />}
-                            >Delete
-                            </Button>;
-
-                            const add_users_button = <Button
-                                onClick={() => {
-                                    getGroupMembers(row.name);
-                                    getAllUsers();
-                                    setGroup(row.name);
-                                    setShowAddUserToGroup(true);
-                                }}
-                                key={`${row.name}_add`}
-                                rightSection={<IconUserCog size={14} />}
-                            >Manage Users</Button>;
-
-                            tableData.body.push([row.name, row.created, row.type, parseInt(row.bitpos, 2), row.description, add_users_button, delete_button]);
-                            console.log(tableData)
-                        }
-                    });
+                    const rows: Group[] = r.data.results.map((row: any) => ({
+                        name: row.name,
+                        created: row.created,
+                        type: row.type,
+                        bitpos: parseInt(row.bitpos, 2),
+                        description: row.description,
+                    }));
                     setPage(r.data.current_page);
-                    setTotalPages(r.data.total_pages);
-                    setGroups(tableData);
+                    setTotalRecords(r.data.total);
+                    setGroups(rows);
                 }
             }).catch((err) => {
-            console.log(err);
-            notifications.show({
-                title: t('Failed to get groups'),
-                message: err.response.data.error,
-                icon: <IconX />,
-                color: 'red',
+                setLoading(false);
+                console.log(err);
+                notifications.show({
+                    title: t('Failed to get groups'),
+                    message: err.response.data.error,
+                    icon: <IconX />,
+                    color: 'red',
+                });
             });
-        })
     }
 
     function addGroup() {
@@ -246,8 +242,13 @@ export default function Groups() {
     }
 
     useEffect(() => {
+        setPage(1);
         get_groups();
-    }, [activePage]);
+    }, [pageSize]);
+
+    useEffect(() => {
+        get_groups();
+    }, [activePage, sortStatus]);
 
     return (
         <>
@@ -318,9 +319,62 @@ export default function Groups() {
                 </Center>
             </Modal>
             <Table.ScrollContainer minWidth="100%">
-                <Table data={groups} stripedColor={computedColorScheme === 'light' ? 'gray.2' : 'dark.8'} highlightOnHoverColor={computedColorScheme === 'light' ? 'gray.4' : 'dark.6'} striped="odd" highlightOnHover withTableBorder mt="md" mb="md" />
+                <DataTable
+                    withTableBorder
+                    borderRadius="md"
+                    shadow="sm"
+                    striped
+                    highlightOnHover
+                    records={groups}
+                    columns={[
+                        { accessor: 'name', title: t('Name'), sortable: true },
+                        { accessor: 'created', title: t('Created'), sortable: true },
+                        { accessor: 'type', title: t('Type'), sortable: true },
+                        { accessor: 'bitpos', title: t('Bit Position'), sortable: true },
+                        { accessor: 'description', title: t('Description'), sortable: true },
+                        {
+                            accessor: 'actions_manage',
+                            title: '',
+                            render: (row: Group) => (
+                                <Button
+                                    onClick={() => {
+                                        getGroupMembers(row.name);
+                                        getAllUsers();
+                                        setGroup(row.name);
+                                        setShowAddUserToGroup(true);
+                                    }}
+                                    rightSection={<IconUserCog size={14} />}
+                                >Manage Users</Button>
+                            ),
+                        },
+                        {
+                            accessor: 'actions_delete',
+                            title: '',
+                            render: (row: Group) => (
+                                <Button
+                                    color="red"
+                                    onClick={() => {
+                                        setGroupToDelete(row.name);
+                                        setDeleteGroupOpen(true);
+                                    }}
+                                    disabled={row.name === "__ANON__"}
+                                    rightSection={<IconCircleMinus size={14} />}
+                                >Delete</Button>
+                            ),
+                        },
+                    ]}
+                    page={activePage}
+                    onPageChange={(p) => setPage(p)}
+                    onRecordsPerPageChange={setPageSize}
+                    totalRecords={totalRecords}
+                    recordsPerPage={pageSize}
+                    recordsPerPageOptions={[10, 15, 20, 25, 30, 35, 40, 45, 50]}
+                    sortStatus={sortStatus}
+                    onSortStatusChange={setSortStatus}
+                    fetching={loading}
+                    minHeight={180}
+                />
             </Table.ScrollContainer>
-            <Center><Pagination total={totalPages} value={activePage} onChange={setPage} withEdges /></Center>
         </>
     )
 }

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -320,6 +320,8 @@ export default function Users() {
                 shadow="sm"
                 striped
                 highlightOnHover
+                horizontalSpacing="xs"
+                scrollAreaProps={{ type: 'auto', offsetScrollbars: true }}
                 records={users}
                 columns={[
                     {

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -2,14 +2,13 @@ import {
     Button,
     Center, Grid,
     Modal, MultiSelect,
-    Pagination, Paper,
+    Paper,
     PasswordInput,
     Select,
     Switch,
-    Table,
     TableData,
     ComboboxItem,
-    TextInput, useComputedColorScheme, Title, Tooltip, LoadingOverlay,
+    TextInput, Title, Tooltip,
 } from '@mantine/core';
 import React, { useEffect, useState } from 'react';
 import {
@@ -26,15 +25,29 @@ import axios from '../axios_config';
 import { apiRoutes } from '../apiRoutes';
 import {t} from "i18next";
 import {Link} from "react-router";
+import { DataTable, type DataTableSortStatus } from 'mantine-datatable';
+
+export interface User {
+    username: string;
+    roles: { name: string }[];
+    active: boolean;
+    last_login_at: string | null;
+    last_login_ip: string | null;
+    current_login_at: string | null;
+    current_login_ip: string | null;
+    login_count: number;
+}
 
 export default function Users() {
-    const [users, setUsers] = useState<TableData>({
-        caption: '',
-        head: [t('Username'), t('Role'), t('Active'), t('Last Login'), t('Last Login IP'), t('Current Login'), t('Current Login IP'), t('Login Count')],
-        body: [],
-    });
+    const [users, setUsers] = useState<User[]>([]);
+    const [userCount, setUserCount] = useState<number>(0);
     const [activePage, setPage] = useState(1);
     const [totalPages, setTotalPages] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const [sortStatus, setSortStatus] = useState<DataTableSortStatus<User>>({
+        columnAccessor: 'username',
+        direction: 'asc',
+    });
     const [addUserOpen, setAddUserOpen] = useState(false);
     const [showResetPassword, setShowResetPassword] = useState(false);
     const [showDeleteUser, setShowDeleteUser] = useState(false);
@@ -51,93 +64,38 @@ export default function Users() {
         head: [t('Group Name'), t('Direction'), t('Active')],
         body: [],
     });
-    const computedColorScheme = useComputedColorScheme('light', { getInitialValueInEffect: true });
 
     function getUsers() {
         setLoading(true);
-        axios.get(apiRoutes.users, { params: { page: activePage,} }).then(r => {
+        axios.get(apiRoutes.users, {
+            params: {
+                page: activePage,
+                per_page: pageSize,
+                sort_by: sortStatus.columnAccessor,
+                sort_direction: sortStatus.direction,
+            }
+        }).then(r => {
             setLoading(false);
             if (r.status === 200) {
-                const tableData: TableData = {
-                    caption: '',
-                    head: [t('Username'), t('Role'), t('Active'), t('Last Login'), t('Last Login IP'), t('Current Login'), t('Current Login IP'), t('Login Count')],
-                    body: [],
-                };
-
-                r.data.results.map((row:any) => {
-                    if (tableData.body !== undefined) {
-                        const reset_password_button = <Button
-                          onClick={() => {
-                            setShowResetPassword(true);
-                            setUsername(row.username);
-                        }}
-                          rightSection={<IconPassword />}
-                        >Reset Password</Button>;
-
-                        const user_profile_link = <Link to={`/profile/${row.username}`}>{row.username}</Link>
-
-                        const manage_groups_button = <Button
-                            rightSection={<IconUserCog />}
-                            onClick={() => {
-                                setShowManageGroups(true);
-                                getAllGroups();
-                                getMemberships(row.username);
-                                setUsername(row.username);
-                            }}
-                        >Manage Groups</Button>;
-
-                        const delete_user_button = <Button
-                            color='red'
-                          disabled={row.username === localStorage.getItem('username')}
-                            rightSection={<IconUserMinus />}
-                          onClick={() => {
-                            setUsername(row.username);
-                            setShowDeleteUser(true);
-                        }}
-                        >Delete User</Button>;
-
-                        const active_switch = <Switch
-                          disabled={row.username === localStorage.getItem('username')}
-                          checked={row.active}
-                          onChange={(e) => {
-                            if (e.target.checked) { activateUser(row.username); } else { deactivateUser(row.username); }
-                        }}
-                        />;
-
-                        const role_select = <Select
-                          value={row.roles[0].name}
-                          onChange={(_value, option) => {
-                            changeRole(row.username, option.value);
-                        }}
-                          data={[{ value: 'administrator', label: 'Administrator' }, { value: 'user', label: 'User' }]}
-                          placeholder="Role"
-                        />;
-
-                        tableData.body.push([user_profile_link, (row.username === localStorage.getItem('username') ? row.roles[0].name : role_select),
-                            active_switch, row.last_login_at, row.last_login_ip, row.current_login_at, row.current_login_ip, row.login_count,
-                            reset_password_button, manage_groups_button, delete_user_button]);
-                    }
-                    });
-
-                    setPage(r.data.current_page);
-                    setTotalPages(r.data.total_pages);
-                    setUsers(tableData);
-                }
-            }).catch((err) => {
-                setLoading(false)
-                console.log(err);
-                notifications.show({
-                    title: t('Failed to get users'),
-                    message: err.response.data.error,
-                    icon: <IconX />,
-                    color: 'red',
-                });
+                setUsers(r.data.results);
+                setPage(r.data.current_page);
+                setTotalPages(r.data.total_pages);
+                setUserCount(r.data.total);
+            }
+        }).catch((err) => {
+            setLoading(false);
+            console.log(err);
+            notifications.show({
+                title: t('Failed to get users'),
+                message: err.response.data.error,
+                icon: <IconX />,
+                color: 'red',
             });
-        }
+        });
+    }
 
-    useEffect(() => {
-        getUsers();
-    }, [activePage]);
+    useEffect(() => { setPage(1); getUsers(); }, [pageSize]);
+    useEffect(() => { getUsers(); }, [activePage, sortStatus]);
 
     function getAllGroups() {
         axios.get(apiRoutes.allGroups).then(r => {
@@ -355,13 +313,126 @@ export default function Users() {
 
     return (
         <>
-            <LoadingOverlay visible={loading} zIndex={1000} overlayProps={{ radius: "sm", blur: 2 }} />
-
             <Button onClick={() => { setAddUserOpen(true); }} mb="md" leftSection={<IconUserPlus size={14} />}>Add User</Button>
-            <Table.ScrollContainer minWidth="100%">
-                <Table data={users} stripedColor={computedColorScheme === 'light' ? 'gray.2' : 'dark.8'} highlightOnHoverColor={computedColorScheme === 'light' ? 'gray.4' : 'dark.6'} striped="odd" highlightOnHover withTableBorder mb="md" />
-            </Table.ScrollContainer>
-            <Center><Pagination total={totalPages} value={activePage} onChange={setPage} withEdges /></Center>
+            <DataTable
+                withTableBorder
+                borderRadius="md"
+                shadow="sm"
+                striped
+                highlightOnHover
+                records={users}
+                columns={[
+                    {
+                        accessor: 'username',
+                        title: t('Username'),
+                        sortable: true,
+                        render: (row) => <Link to={`/profile/${row.username}`}>{row.username}</Link>,
+                    },
+                    {
+                        accessor: 'role',
+                        title: t('Role'),
+                        render: (row) => row.username === localStorage.getItem('username')
+                            ? row.roles[0]?.name
+                            : (
+                                <Select
+                                    value={row.roles[0]?.name}
+                                    onChange={(_value, option) => { changeRole(row.username, option.value); }}
+                                    data={[{ value: 'administrator', label: 'Administrator' }, { value: 'user', label: 'User' }]}
+                                    placeholder="Role"
+                                />
+                            ),
+                    },
+                    {
+                        accessor: 'active',
+                        title: t('Active'),
+                        render: (row) => (
+                            <Switch
+                                disabled={row.username === localStorage.getItem('username')}
+                                checked={row.active}
+                                onChange={(e) => {
+                                    if (e.target.checked) { activateUser(row.username); } else { deactivateUser(row.username); }
+                                }}
+                            />
+                        ),
+                    },
+                    {
+                        accessor: 'last_login_at',
+                        title: t('Last Login'),
+                        sortable: true,
+                    },
+                    {
+                        accessor: 'last_login_ip',
+                        title: t('Last Login IP'),
+                    },
+                    {
+                        accessor: 'current_login_at',
+                        title: t('Current Login'),
+                        sortable: true,
+                    },
+                    {
+                        accessor: 'current_login_ip',
+                        title: t('Current Login IP'),
+                    },
+                    {
+                        accessor: 'login_count',
+                        title: t('Login Count'),
+                        sortable: true,
+                    },
+                    {
+                        accessor: 'reset_password',
+                        title: '',
+                        render: (row) => (
+                            <Button
+                                onClick={() => {
+                                    setShowResetPassword(true);
+                                    setUsername(row.username);
+                                }}
+                                rightSection={<IconPassword />}
+                            >Reset Password</Button>
+                        ),
+                    },
+                    {
+                        accessor: 'manage_groups',
+                        title: '',
+                        render: (row) => (
+                            <Button
+                                rightSection={<IconUserCog />}
+                                onClick={() => {
+                                    setShowManageGroups(true);
+                                    getAllGroups();
+                                    getMemberships(row.username);
+                                    setUsername(row.username);
+                                }}
+                            >Manage Groups</Button>
+                        ),
+                    },
+                    {
+                        accessor: 'delete_user',
+                        title: '',
+                        render: (row) => (
+                            <Button
+                                color='red'
+                                disabled={row.username === localStorage.getItem('username')}
+                                rightSection={<IconUserMinus />}
+                                onClick={() => {
+                                    setUsername(row.username);
+                                    setShowDeleteUser(true);
+                                }}
+                            >Delete User</Button>
+                        ),
+                    },
+                ]}
+                page={activePage}
+                onPageChange={(p) => setPage(p)}
+                onRecordsPerPageChange={setPageSize}
+                totalRecords={userCount}
+                recordsPerPage={pageSize}
+                recordsPerPageOptions={[10, 15, 20, 25, 30, 35, 40, 45, 50]}
+                sortStatus={sortStatus}
+                onSortStatusChange={setSortStatus}
+                fetching={loading}
+                minHeight={180}
+            />
             <Modal size="lg" opened={showManageGroups} onClose={() => setShowManageGroups(false)} title={`Manage Groups for ${username}`}>
                 <Paper withBorder p="md" mb="md">
                     <Grid align="flex-end" justify="space-between">
@@ -400,9 +471,26 @@ export default function Users() {
                     </Grid>
                 </Paper>
                 <Title order={4} mb="md">{t("Memberships")}</Title>
-                <Table.ScrollContainer minWidth="100%">
-                    <Table data={memberships} stripedColor={computedColorScheme === 'light' ? 'gray.2' : 'dark.8'} highlightOnHoverColor={computedColorScheme === 'light' ? 'gray.4' : 'dark.6'} striped="odd" highlightOnHover withTableBorder mt="md" mb="md" />
-                </Table.ScrollContainer>
+                <DataTable
+                    withTableBorder
+                    borderRadius="md"
+                    striped
+                    highlightOnHover
+                    records={memberships.body?.map((row: any[], idx: number) => ({
+                        id: idx,
+                        group_name: row[0],
+                        direction: row[1],
+                        active: row[2],
+                        actions: row[3],
+                    }))}
+                    columns={[
+                        { accessor: 'group_name', title: t('Group Name') },
+                        { accessor: 'direction', title: t('Direction') },
+                        { accessor: 'active', title: t('Active') },
+                        { accessor: 'actions', title: '' },
+                    ]}
+                    minHeight={120}
+                />
             </Modal>
             <Modal opened={addUserOpen} onClose={() => setAddUserOpen(false)} title={t("Add User")}>
                 <TextInput required label="Username" placeholder="Username" onChange={e => { setUsername(e.target.value); }} />


### PR DESCRIPTION
## Summary

- Convert Users and Groups pages from plain Mantine `<Table>` + `<Pagination>` to `mantine-datatable` `<DataTable>`, matching the pattern already used by EUDs, Data Packages, Video Streams, etc.
- Adds sortable columns (click headers to sort), configurable records-per-page selector, and loading state indicator
- All existing functionality preserved: action buttons (Reset Password, Manage Groups, Delete User), role selector, active toggle, group member management modal
- Horizontal scrollbar uses `offsetScrollbars` to avoid overlapping the last row

### Users page
Sortable columns: Username, Last Login, Current Login, Login Count

### Groups page
Sortable columns: Name, Created, Type, Bit Position, Description

## Test plan

- [ ] Users page: click column headers to sort, change records per page
- [ ] Users page: Reset Password, Manage Groups, Delete User buttons still work
- [ ] Users page: Role dropdown and Active toggle still work
- [ ] Groups page: click column headers to sort, change records per page
- [ ] Groups page: Add Group, Manage Users, Delete Group still work
- [ ] Groups page: member table inside Manage Users modal still displays correctly
- [ ] Horizontal scrollbar doesn't cover last row content

Companion backend PR: brian7704/OpenTAKServer#285
Addresses brian7704/OpenTAKServer#282

🤖 Generated with [Claude Code](https://claude.com/claude-code)