### PR TITLE
Fix authentication bypass on unknown routes

### DIFF
--- a/src/DefaultLayout.tsx
+++ b/src/DefaultLayout.tsx
@@ -16,7 +16,7 @@ import {
     IconAlertTriangle,
     IconUser,
 } from '@tabler/icons-react';
-import { useNavigate } from 'react-router';
+import { Navigate, useNavigate } from 'react-router';
 import { notifications } from '@mantine/notifications';
 import Logo from './images/ots-logo.png';
 import { AppContent } from './components/AppContent';
@@ -27,6 +27,11 @@ import { socket } from './socketio';
 import {t} from "i18next";
 
 export function DefaultLayout() {
+    const loggedIn = JSON.parse(String(localStorage.getItem('loggedIn'))) === true;
+    if (!loggedIn) {
+        return <Navigate to="/login" />;
+    }
+
     const [mobileOpened, { toggle: toggleMobile }] = useDisclosure();
     const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
     const computedColorScheme = useComputedColorScheme('light', { getInitialValueInEffect: true });


### PR DESCRIPTION
## Summary

Unauthenticated users hitting any non-existent route (e.g. `/abc123`) saw the full UI shell (navbar, sidebar, header) because `DefaultLayout` rendered unconditionally. The auth check only existed inside `AppContent`'s `PrivateRoute` wrapper, which didn't cover the shell itself.

This adds an auth check at the top of `DefaultLayout` that redirects to `/login` if the user isn't authenticated, preventing the shell from rendering at all for unauthenticated users regardless of the route.

## What this does NOT change

As Brian noted in brian7704/OpenTAKServer#247, the backend API endpoints already properly reject unauthenticated requests — this was a UI-only issue where the shell appeared to be logged in but API calls would fail.

The truststore (`GET /api/truststore`) remains intentionally available without authentication as it is a public key. While the UI navbar will no longer be visible to unauthenticated users (so they won't see the download button), the endpoint itself is unchanged and the truststore can still be downloaded directly by anyone who knows the URL.

## Test plan

- [ ] Open an incognito window, navigate to `https://<server>/abc123` — should redirect to `/login`
- [ ] Open an incognito window, navigate to `https://<server>/users` — should redirect to `/login`
- [ ] Log in normally — all pages work as before
- [ ] `curl https://<server>/api/truststore` without auth — still returns the truststore file

Fixes brian7704/OpenTAKServer#247

🤖 Generated with [Claude Code](https://claude.com/claude-code)