### PR TITLE
Fix Mission dialog title reset and add unsaved-changes warning

### DIFF
--- a/src/pages/Missions.tsx
+++ b/src/pages/Missions.tsx
@@ -58,6 +58,8 @@ export default function Missions() {
     const [addEditTitle, setAddEditTitle] = useState(t("Add Mission"));
     const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
     const [loading, setLoading] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+    const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
     const [sortStatus, setSortStatus] = useState<DataTableSortStatus<MissionProperties>>({
         columnAccessor: 'name',
         direction: 'asc',
@@ -156,6 +158,7 @@ export default function Missions() {
                                 });
                                 setShowAddMission(true);
                                 setAddEditTitle(t("Edit Mission"));
+                                setIsDirty(false);
                                 let selected_groups: string[] = [];
                                 row.groups.map((group: any) => {
                                     selected_groups.push("" + group.id);
@@ -397,9 +400,15 @@ export default function Missions() {
                     <Button onClick={() => setDeleteMissionOpen(false)}>No</Button>
                 </Center>
             </Modal>
-            <Modal opened={showAddMission} onClose={() => {setShowAddMission(false);}} title={addEditTitle}>
-                <TextInput defaultValue={missionProperties.name} required placeholder={t("Mission")} label={t("Name")} onChange={e => { missionProperties.name = e.target.value; }} mb="md" />
-                <TextInput defaultValue={missionProperties.description} placeholder={t("Description")} label={t("Description")} onChange={e => { missionProperties.description = e.target.value; }} mb="md" />
+            <Modal opened={showUnsavedWarning} onClose={() => setShowUnsavedWarning(false)} title={t("Discard unsaved changes?")}>
+                <Center>
+                    <Button mr="md" color="red" onClick={() => { setShowUnsavedWarning(false); setIsDirty(false); setShowAddMission(false); }}>{t("Discard")}</Button>
+                    <Button onClick={() => setShowUnsavedWarning(false)}>{t("Keep editing")}</Button>
+                </Center>
+            </Modal>
+            <Modal opened={showAddMission} onClose={() => { if (isDirty) { setShowUnsavedWarning(true); } else { setShowAddMission(false); } }} title={addEditTitle}>
+                <TextInput defaultValue={missionProperties.name} required placeholder={t("Mission")} label={t("Name")} onChange={e => { missionProperties.name = e.target.value; setIsDirty(true); }} mb="md" />
+                <TextInput defaultValue={missionProperties.description} placeholder={t("Description")} label={t("Description")} onChange={e => { missionProperties.description = e.target.value; setIsDirty(true); }} mb="md" />
                 <MultiSelect
                     pb="md"
                     placeholder={t("Search")}
@@ -408,12 +417,12 @@ export default function Missions() {
                     nothingFoundMessage={t("Nothing found...")}
                     label={t("Groups")}
                     defaultValue={selectedGroups}
-                    onChange={(value) => {setGroups(value)}}
+                    onChange={(value) => { setGroups(value); setIsDirty(true); }}
                     data={allGroups} />
                 <Select
                     required
                     label={t("Default Role")}
-                    onChange={e => { missionProperties.default_role = String(e); }}
+                    onChange={e => { missionProperties.default_role = String(e); setIsDirty(true); }}
                     data={[{value: 'MISSION_SUBSCRIBER', label: t('Subscriber')}, {value: 'MISSION_OWNER', label: t('Owner')}, {value: 'MISSION_READ_ONLY', label: t('Read Only')}]}
                     mb="md"
                     defaultValue={missionProperties.default_role || "MISSION_SUBSCRIBER"}
@@ -426,16 +435,18 @@ export default function Missions() {
                     nothingFoundMessage={t("Nothing found...")}
                     label={t("Creator")}
                     description={t("The callsign of the EUD that owns this mission")}
-                    onChange={(value, option) => {missionProperties.creator_uid = option.value;}}
+                    onChange={(value, option) => { missionProperties.creator_uid = option.value; setIsDirty(true); }}
                     data={callsigns}
                     defaultValue={missionProperties.creator_uid}
                     allowDeselect={false}
                     mb="md" />
-                <PasswordInput defaultValue={missionProperties.password} label={t("Password")} onChange={e => { missionProperties.password = e.target.value; }} mb="md" />
-                <Button onClick={() => {add_mission()}}>{addEditTitle}</Button>
+                <PasswordInput defaultValue={missionProperties.password} label={t("Password")} onChange={e => { missionProperties.password = e.target.value; setIsDirty(true); }} mb="md" />
+                <Button onClick={() => { setIsDirty(false); add_mission(); }}>{addEditTitle}</Button>
             </Modal>
             <Button leftSection={<IconPlus size={14} />} mb="md" onClick={() => {
                 setShowAddMission(true);
+                setAddEditTitle(t("Add Mission"));
+                setIsDirty(false);
                 setMissionProperties({
                     name: "",
                     description: "",


### PR DESCRIPTION
## Summary

- Addresses Issues 1 and 2 of #180.
- **Issue 1**: After editing a mission, clicking "New Mission" again now correctly shows "Add Mission" as the dialog title and submit button label, instead of the stale "Edit Mission".
- **Issue 2**: Closing the mission dialog (outside-click, ESC, or close button) with unsaved changes now opens a confirmation prompt instead of silently discarding the work. Saving or discarding clears the dirty flag.

## Issue 3 — out of scope

Issue 3 (no UI to remove an existing mission password) needs a backend change before it can be done cleanly:

- The `DELETE /Marti/api/missions/<name>/password` endpoint cited in the issue requires a Data Sync token / iTAK certificate and is not callable from the admin web UI.
- The `/api/missions` POST handler ignores `password: ""` on create (`mission_api.py:103`).
- The PUT/edit branch would set `password=""` but does not recompute `password_protected`, leaving stale state.

This needs a separate UI + backend PR.

## Test plan

- [ ] Open "New Mission", close, click Edit on a mission, close, click "New Mission" — dialog title and submit button both read "Add Mission".
- [ ] Open "New Mission", type into Name, press ESC — confirmation prompt appears. "Discard" closes both dialogs; "Keep editing" only closes the prompt.
- [ ] Open "New Mission", click outside dialog without typing anything — closes silently (no false-positive prompt).
- [ ] Submitting a new or edited mission via the dialog button still works and clears the dirty flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)